### PR TITLE
Add object caching and missing object finder to PlanhatClient

### DIFF
--- a/tasks.py
+++ b/tasks.py
@@ -162,6 +162,12 @@ def build(ctx):
 
 
 @task
+def publish(ctx):
+    """Publish to PyPI"""
+    poetry(ctx, "publish")
+
+
+@task
 def docs(ctx):
     """Build API documentation"""
     output_path = ROOT / "docs" / "api"


### PR DESCRIPTION
This pull request adds two new features to the PlanhatClient:

- Object caching: A dictionary cache is added to the client to store objects that have already been retrieved from Planhat. This reduces the number of API calls made to Planhat and improves performance.

- Missing object finder: A new method is added to the client that finds objects missing in Planhat from a list of objects provided. This is useful for ensuring data consistency between Planhat and other systems.

Commits included in this pull request:

- Add publish task to tasks.py

- Add object caching and missing object finder to PlanhatClient

No issues or pull requests are referenced in the commits.